### PR TITLE
Add Set Session Param Webhook sample

### DIFF
--- a/dialogflow-cx/delegators/__init__.py
+++ b/dialogflow-cx/delegators/__init__.py
@@ -17,7 +17,7 @@
 from .agent_delegator import AgentDelegator
 from .auth_delegator import AuthDelegator
 from .client_delegator import ClientDelegator
-from .intent_delegator import IntentDelegator
+from .intent_delegator import AnnotatedIntentDelegator, IntentDelegator
 from .page_delegator import FulfillmentPageDelegator, PageDelegator, StartPageDelegator
 from .sessions_delegator import SessionsDelegator
 from .start_flow_delegator import StartFlowDelegator
@@ -29,6 +29,7 @@ __all__ = (
     "AuthDelegator",
     "ClientDelegator",
     "IntentDelegator",
+    "AnnotatedIntentDelegator",
     "FulfillmentPageDelegator",
     "PageDelegator",
     "StartPageDelegator",

--- a/dialogflow-cx/delegators/intent_delegator.py
+++ b/dialogflow-cx/delegators/intent_delegator.py
@@ -42,8 +42,7 @@ class IntentDelegator(ClientDelegator):
             raise RuntimeError("Intent not yet created")
         return self._intent
 
-    def setup(self):
-        """Initializes the intent delegator."""
+    def get_intent(self):
         training_phrases = []
         for training_phrase_text in self.training_phrases:
             training_phrase = cx.Intent.TrainingPhrase(
@@ -55,12 +54,16 @@ class IntentDelegator(ClientDelegator):
             )
             training_phrases.append(training_phrase)
 
-        intent = cx.Intent(
+        return cx.Intent(
             {
                 "display_name": self.display_name,
                 "training_phrases": training_phrases,
             }
         )
+
+    def setup(self):
+        """Initializes the intent delegator."""
+        intent = self.get_intent()
         try:
             self._intent = self.client.create_intent(
                 parent=self.parent,
@@ -86,3 +89,24 @@ class IntentDelegator(ClientDelegator):
             self._intent = None
         except google.api_core.exceptions.NotFound:
             pass
+
+
+class AnnotatedIntentDelegator(IntentDelegator):
+    def __init__(
+        self,
+        controller: ds.DialogflowSample,
+        training_phrases: List[cx.Intent.TrainingPhrase.Part],
+        parameters: List[cx.Intent.Parameter],
+        **kwargs,
+    ) -> None:
+        super().__init__(controller, training_phrases=training_phrases, **kwargs)
+        self.parameters = parameters
+
+    def get_intent(self):
+        return cx.Intent(
+            {
+                "display_name": self.display_name,
+                "training_phrases": self.training_phrases,
+                "parameters": self.parameters,
+            }
+        )

--- a/dialogflow-cx/delegators/intent_delegator.py
+++ b/dialogflow-cx/delegators/intent_delegator.py
@@ -43,6 +43,7 @@ class IntentDelegator(ClientDelegator):
         return self._intent
 
     def get_intent(self):
+        """Create and Intent object to be pushed to the API."""
         training_phrases = []
         for training_phrase_text in self.training_phrases:
             training_phrase = cx.Intent.TrainingPhrase(
@@ -92,6 +93,8 @@ class IntentDelegator(ClientDelegator):
 
 
 class AnnotatedIntentDelegator(IntentDelegator):
+    """IntentDelegator with annotated spans of text for parameter detection."""
+
     def __init__(
         self,
         controller: ds.DialogflowSample,
@@ -103,6 +106,7 @@ class AnnotatedIntentDelegator(IntentDelegator):
         self.parameters = parameters
 
     def get_intent(self):
+        """Create and Intent object to be pushed to the API, including parameters."""
         return cx.Intent(
             {
                 "display_name": self.display_name,

--- a/dialogflow-cx/delegators/sessions_delegator.py
+++ b/dialogflow-cx/delegators/sessions_delegator.py
@@ -39,9 +39,11 @@ class SessionsDelegator(ClientDelegator):
         **kwargs,
     ):
         """Run detect_intent for a session against an Agent."""
-        parameters = kwargs.pop('parameters', {})
-        session_id = kwargs.pop('session_id', str(uuid.uuid1()))
-        current_page = kwargs.pop('current_page', self.controller.start_flow_delegator.start_page_name)
+        parameters = kwargs.pop("parameters", {})
+        session_id = kwargs.pop("session_id", str(uuid.uuid1()))
+        current_page = kwargs.pop(
+            "current_page", self.controller.start_flow_delegator.start_page_name
+        )
 
         request = cx.DetectIntentRequest(
             session=f"{self.controller.agent_delegator.agent.name}/sessions/{session_id}",
@@ -70,6 +72,8 @@ class SessionsDelegator(ClientDelegator):
 
         # Parameters that are "None" are removed from the session. drop_none_params=True performs the same behavior client-side, to stay in-sync
         if drop_none_params:
-            parameters = {key:val for key, val in parameters.items() if val is not None}
+            parameters = {
+                key: val for key, val in parameters.items() if val is not None
+            }
 
         return responses, current_page, parameters

--- a/dialogflow-cx/delegators/sessions_delegator.py
+++ b/dialogflow-cx/delegators/sessions_delegator.py
@@ -70,7 +70,9 @@ class SessionsDelegator(ClientDelegator):
             else:
                 parameters = dict(parameters)
 
-        # Parameters that are "None" are removed from the session. drop_none_params=True performs the same behavior client-side, to stay in-sync
+        # Parameters that are "None" are removed from the session.
+        #  drop_none_params=True performs the same behavior client-side,
+        #  to stay in-sync
         if drop_none_params:
             parameters = {
                 key: val for key, val in parameters.items() if val is not None

--- a/dialogflow-cx/delegators/sessions_delegator.py
+++ b/dialogflow-cx/delegators/sessions_delegator.py
@@ -35,20 +35,13 @@ class SessionsDelegator(ClientDelegator):
     def detect_intent(
         self,
         text,
-        current_page=None,
-        session_id=None,
-        parameters=None,
+        drop_none_params=True,
+        **kwargs,
     ):
         """Run detect_intent for a session against an Agent."""
-
-        if parameters is None:
-            parameters = {}
-
-        if not session_id:
-            session_id = str(uuid.uuid1())
-
-        if not current_page:
-            current_page = self.controller.start_flow_delegator.start_page_name
+        parameters = kwargs.pop('parameters', {})
+        session_id = kwargs.pop('session_id', str(uuid.uuid1()))
+        current_page = kwargs.pop('current_page', self.controller.start_flow_delegator.start_page_name)
 
         request = cx.DetectIntentRequest(
             session=f"{self.controller.agent_delegator.agent.name}/sessions/{session_id}",
@@ -74,4 +67,9 @@ class SessionsDelegator(ClientDelegator):
                 parameters = {}
             else:
                 parameters = dict(parameters)
+
+        # Parameters that are "None" are removed from the session. drop_none_params=True performs the same behavior client-side, to stay in-sync
+        if drop_none_params:
+            parameters = {key:val for key, val in parameters.items() if val is not None}
+
         return responses, current_page, parameters

--- a/dialogflow-cx/set_session_param_sample.py
+++ b/dialogflow-cx/set_session_param_sample.py
@@ -1,0 +1,188 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Dialogflow CX Sample: Set session param with a webhook."""
+
+import delegators as dg
+import dialogflow_sample as ds
+import google.cloud.dialogflowcx as cx
+from webhook.main import get_webhook_uri
+
+
+def get_expected_response():
+    return "Session parameter set"
+
+
+class SetSessionParamSample(ds.DialogflowSample):
+    """Sets up a Dialogflow agent that uses a webhook to provide an entry fulfillment."""
+
+    _WEBHOOK_DISPLAY_NAME = "Set Session Parameter"
+    _INTENT_DISPLAY_NAME = "set-session-param"
+    _INTENT_TRAINING_PHRASE_TEXT = "set session parameter API to Dialogflow"
+    _PAGE_DISPLAY_NAME = "Main Page"
+    _PAGE_ENTRY_FULFILLMENT_TEXT = f"Entering {_PAGE_DISPLAY_NAME}"
+    _PAGE_WEBHOOK_ENTRY_TAG = "set_session_param"
+
+    def __init__(
+        self,
+        project_id=None,
+        quota_project_id=None,
+        webhook_uri=None,
+        agent_display_name=None,
+    ):
+        super().__init__()
+        if not quota_project_id:
+            quota_project_id = project_id
+        self.set_auth_delegator(
+            dg.AuthDelegator(
+                self,
+                project_id=project_id,
+                quota_project_id=quota_project_id,
+            )
+        )
+        self.set_agent_delegator(
+            dg.AgentDelegator(self, display_name=agent_display_name)
+        )
+        self.webhook_delegator = dg.WebhookDelegator(
+            self, display_name=self._WEBHOOK_DISPLAY_NAME, uri=webhook_uri
+        )
+        training_phrases = [
+            cx.Intent.TrainingPhrase(
+                repeat_count=1,
+                parts=[
+                    cx.Intent.TrainingPhrase.Part(text="Set session parameter "),
+                    cx.Intent.TrainingPhrase.Part(
+                        text="session_param",
+                        parameter_id="key",
+                    ),
+                    cx.Intent.TrainingPhrase.Part(text=" to "),
+                    cx.Intent.TrainingPhrase.Part(
+                        text="value",
+                        parameter_id="val",
+                    ),
+                ],
+            )
+        ]
+        parameters = [
+            cx.Intent.Parameter(
+                id="key",
+                entity_type="projects/-/locations/-/agents/-/entityTypes/sys.any",
+            ),
+            cx.Intent.Parameter(
+                id="val",
+                entity_type="projects/-/locations/-/agents/-/entityTypes/sys.any",
+            ),
+        ]
+        self.intent_delegator = dg.AnnotatedIntentDelegator(
+            self,
+            display_name=self._INTENT_DISPLAY_NAME,
+            training_phrases=training_phrases,
+            parameters=parameters,
+        )
+        self.page_delegator = dg.FulfillmentPageDelegator(
+            self,
+            display_name=self._PAGE_DISPLAY_NAME,
+            entry_fulfillment_text=self._PAGE_ENTRY_FULFILLMENT_TEXT,
+            webhook_delegator=self.webhook_delegator,
+            tag=self._PAGE_WEBHOOK_ENTRY_TAG,
+        )
+        self.set_start_flow_delegator(dg.StartFlowDelegator(self))
+        self.set_session_delegator(dg.SessionsDelegator(self))
+        self.start_page_delegator = dg.StartPageDelegator(self)
+
+    def setup(self, wait=1):
+        """Initializes the sample by communicating with the Dialogflow API."""
+        self.agent_delegator.setup()
+        self.webhook_delegator.setup()
+        self.intent_delegator.setup()
+        self.page_delegator.setup()
+        self.start_flow_delegator.setup()
+        self.start_flow_delegator.append_transition_route(
+            target_page=self.page_delegator.page.name,
+            intent=self.intent_delegator.intent.name,
+        )
+        super().setup(wait=wait)
+
+    def tear_down(self):
+        """Deletes the sample components via the Dialogflow API."""
+        self.page_delegator.tear_down()
+        self.start_flow_delegator.tear_down()
+        self.intent_delegator.tear_down()
+        self.webhook_delegator.tear_down()
+        self.agent_delegator.tear_down()
+
+
+if __name__ == "__main__":
+
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Setup Dialogflow CX basic webhook sample"
+    )
+    parser.add_argument(
+        "--agent-display-name",
+        help="Display name of the Dialogflow CX agent",
+        required=True,
+    )
+    parser.add_argument(
+        "--project-id",
+        help="Google Cloud project to create/use Dialogflow CX in",
+        required=True,
+    )
+    parser.add_argument(
+        "--quota-project-id",
+        help="Quota project, if different from project-id",
+        default=None,
+    )
+    parser.add_argument(
+        "--user-input",
+        nargs="+",
+        help="User text utterances",
+        required=False,
+        default=[],
+    )
+    parser.add_argument(
+        "--tear-down", action="store_true", help="Destroy the agent after run?"
+    )
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument(
+        "--webhook-uri",
+        help=(
+            "Webhook URL for the Dialogflow CX to use. "
+            "Format: https://<region>-<project_id>.cloudfunctions.net/<webhook_name>"
+        ),
+    )
+    group.add_argument(
+        "--build-uuid", help="Infer the webhook URI from the build_uuid and project id"
+    )
+
+    args = vars(parser.parse_args())
+    if args["build_uuid"]:
+        assert not args["webhook_uri"]
+        args["webhook_uri"] = get_webhook_uri(
+            args["project_id"], args.pop("build_uuid")
+        )
+
+    tear_down = args.pop("tear_down")
+    user_input = args.pop("user_input", [])
+    sample = SetSessionParamSample(**args)
+    sample.setup()
+    sample.run(user_input)
+    if tear_down:
+        sample.tear_down()
+    else:
+        print(
+            "Agent sample available at: "
+            f"https://dialogflow.cloud.google.com/cx/{sample.start_flow_delegator.flow.name}"
+        )

--- a/dialogflow-cx/set_session_param_sample.py
+++ b/dialogflow-cx/set_session_param_sample.py
@@ -21,6 +21,7 @@ from webhook.main import get_webhook_uri
 
 
 def get_expected_response():
+    """Gets the response expected from the webhook."""
     return "Session parameter set"
 
 

--- a/dialogflow-cx/tests/test_basic_webhook_sample.py
+++ b/dialogflow-cx/tests/test_basic_webhook_sample.py
@@ -20,7 +20,7 @@ from basic_webhook_sample import BasicWebhookSample
 from utilities import create_conversational_turn, run_hermetic_test
 
 
-@pytest.fixture(name="sample", scope="session")
+@pytest.fixture(name="sample", scope="function")
 def fixture_sample(session_uuid, project_id, webhook_uri):
     """Test fixture reused for all BasicWebhookSample tests."""
     sample = BasicWebhookSample(

--- a/dialogflow-cx/tests/test_set_session_param_sample.py
+++ b/dialogflow-cx/tests/test_set_session_param_sample.py
@@ -36,6 +36,7 @@ def fixture_sample(session_uuid, project_id, webhook_uri):
     del sample
 
 
+#  pylint: disable=too-many-arguments
 @pytest.mark.integration
 @pytest.mark.flaky(max_runs=3, reruns_delay=5)
 @pytest.mark.parametrize(

--- a/dialogflow-cx/tests/test_set_session_param_sample.py
+++ b/dialogflow-cx/tests/test_set_session_param_sample.py
@@ -1,0 +1,95 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Dialogflow CX sample: Setting a session parameter with a webhook."""
+
+
+import dialogflow_sample as ds
+import pytest
+from set_session_param_sample import SetSessionParamSample
+from utilities import create_conversational_turn, run_hermetic_test
+
+
+@pytest.fixture(name="sample", scope="session")
+def fixture_sample(session_uuid, project_id, webhook_uri):
+    """Test fixture reused for all SetSessionParamSample tests."""
+    sample = SetSessionParamSample(
+        agent_display_name=f"SetSessionParamSample (test session {session_uuid})",
+        project_id=project_id,
+        quota_project_id=project_id,
+        webhook_uri=webhook_uri,
+    )
+    sample.setup()
+    yield sample
+    sample.tear_down()
+    del sample
+
+
+@pytest.mark.integration
+@pytest.mark.flaky(max_runs=3, reruns_delay=5)
+@pytest.mark.parametrize(
+    "display_name,user_input,expected_response,expected_params,exception",
+    [
+        (
+            "valid",
+            "set session parameter MOCK_KEY to MOCK_VAL",
+            ["Entering Main Page", "Session parameter set"],
+            {"MOCK_KEY": "MOCK_VAL", "val": None, "key": None},
+            None,
+        ),
+        (
+            "wrong_params",
+            "set session parameter MOCK_KEY to MOCK_VAL",
+            ["Entering Main Page", "Session parameter set"],
+            {},
+            ds.SessionParametersFailure,
+        ),
+        ("wrong_response", "XFAIL", ["XFAIL"], {}, ds.UnexpectedResponseFailure),
+    ],
+)
+def test_set_session_param_sample(
+    display_name, user_input, expected_response, expected_params, exception, sample
+):
+    """Test the SetSessionParamSample test cases."""
+    is_webhook_enabled = True
+    test_case_conversation_turns = [
+        create_conversational_turn(
+            user_input,
+            expected_response,
+            sample.intent_delegator.intent,
+            sample.page_delegator.page,
+            is_webhook_enabled,
+        ),
+    ]
+    expected_session_parameters = [expected_params]
+    test_case = sample.create_test_case(
+        display_name,
+        test_case_conversation_turns,
+    )
+    if exception:
+        with pytest.raises(exception):
+            sample.run_test_case(test_case, expected_session_parameters)
+    else:
+        sample.run_test_case(test_case, expected_session_parameters)
+
+
+@pytest.mark.hermetic
+def test_set_session_param_sample_hermetic():
+    """Test the SetSessionParamSample test cases with mocked API interactions."""
+    sample = SetSessionParamSample(
+        agent_display_name="MOCK_AGENT_DISPLAY_NAME",
+        project_id=-1,
+        webhook_uri="MOCK_WEBHOOK_URI",
+    )
+    run_hermetic_test(sample)

--- a/dialogflow-cx/tests/test_set_session_param_sample.py
+++ b/dialogflow-cx/tests/test_set_session_param_sample.py
@@ -21,7 +21,7 @@ from set_session_param_sample import SetSessionParamSample
 from utilities import create_conversational_turn, run_hermetic_test
 
 
-@pytest.fixture(name="sample", scope="session")
+@pytest.fixture(name="sample", scope="function")
 def fixture_sample(session_uuid, project_id, webhook_uri):
     """Test fixture reused for all SetSessionParamSample tests."""
     sample = SetSessionParamSample(

--- a/dialogflow-cx/tests/test_validate_form_sample.py
+++ b/dialogflow-cx/tests/test_validate_form_sample.py
@@ -20,7 +20,7 @@ from utilities import create_conversational_turn, run_hermetic_test
 from validate_form_sample import ValidateFormSample
 
 
-@pytest.fixture(name="sample", scope="session")
+@pytest.fixture(name="sample", scope="function")
 def fixture_sample(session_uuid, project_id, webhook_uri):
     """Test fixture reused for all ValidateFormSample tests."""
     sample = ValidateFormSample(

--- a/dialogflow-cx/tests/test_webhook.py
+++ b/dialogflow-cx/tests/test_webhook.py
@@ -15,7 +15,12 @@
 """Tests for webhook module."""
 
 import pytest
-from webhook.main import build_request_dict_basic, extract_text, webhook_fcn
+from webhook.main import (
+    build_request_dict_basic,
+    extract_session_parameters,
+    extract_text,
+    webhook_fcn,
+)
 
 
 @pytest.mark.hermetic
@@ -62,3 +67,28 @@ def test_validate_form(mocked_request, test_input, expected):
 
     # Assert:
     assert extract_text(response_json) == expected
+
+
+@pytest.mark.hermetic
+def test_set_session_param(mocked_request):
+    """Locally tests the set session parameter webhook function."""
+
+    # Arrange:
+    mock_key = "MOCK_KEY"
+    mock_val = "MOCK_VAL"
+    request_mapping = {}
+    request_mapping["fulfillmentInfo"] = {}
+    request_mapping["fulfillmentInfo"]["tag"] = "set_session_param"
+    request_mapping["sessionInfo"] = {}
+    request_mapping["sessionInfo"]["parameters"] = {
+        "key": mock_key,
+        "val": mock_val,
+    }
+    mocked_request.payload = request_mapping
+
+    # Act:
+    response_json = webhook_fcn(mocked_request)
+
+    # Assert:
+    assert extract_text(response_json) == "Session parameter set"
+    assert extract_session_parameters(response_json)[mock_key] == mock_val

--- a/dialogflow-cx/webhook/main.py
+++ b/dialogflow-cx/webhook/main.py
@@ -101,6 +101,33 @@ def validate_form(request):
     )
 
 
+def set_session_param(request):
+    request_dict = request.get_json()
+    parameters = request_dict["sessionInfo"]["parameters"]
+    key = parameters["key"]
+    val = parameters["val"]
+    return json.dumps(
+        {
+            "fulfillment_response": {
+                "messages": [
+                    {
+                        "text": {
+                            "text": ["Session parameter set"],
+                        }
+                    }
+                ]
+            },
+            "session_info": {
+                "parameters": {
+                    key: val,
+                    "key": None,
+                    "val": None,
+                }
+            },
+        }
+    )
+
+
 def webhook_fcn(request):
     """Delegates a request to an appropriate function, based on tag."""
     request_dict = request.get_json()
@@ -111,6 +138,8 @@ def webhook_fcn(request):
         return basic_webhook(request)
     if tag == "validate_form":
         return validate_form(request)
+    if tag == "set_session_param":
+        return set_session_param(request)
     raise RuntimeError(f"Unrecognized tag: {tag}")
 
 
@@ -144,3 +173,9 @@ def extract_text(response_json: str, message_index=0):
     response = json.loads(response_json)
     messages = response["fulfillment_response"]["messages"]
     return messages[message_index]["text"]["text"][0]
+
+
+def extract_session_parameters(response_json: str):
+    """Extracts session parameters from the json response of a Dialogflow webhook."""
+    response = json.loads(response_json)
+    return response["session_info"]["parameters"]

--- a/dialogflow-cx/webhook/main.py
+++ b/dialogflow-cx/webhook/main.py
@@ -102,6 +102,7 @@ def validate_form(request):
 
 
 def set_session_param(request):
+    """Sets a session param detected in the intent."""
     request_dict = request.get_json()
     parameters = request_dict["sessionInfo"]["parameters"]
     key = parameters["key"]

--- a/noxfile.py
+++ b/noxfile.py
@@ -18,12 +18,12 @@
 # pylint: disable=missing-module-docstring,missing-function-docstring
 
 from __future__ import absolute_import
-
 import os
 import pathlib
 import shutil
 
 import nox
+
 
 BLACK_VERSION = "black==22.3.0"
 BLACK_PATHS = ["."]

--- a/noxfile.py
+++ b/noxfile.py
@@ -18,12 +18,12 @@
 # pylint: disable=missing-module-docstring,missing-function-docstring
 
 from __future__ import absolute_import
+
 import os
 import pathlib
 import shutil
 
 import nox
-
 
 BLACK_VERSION = "black==22.3.0"
 BLACK_PATHS = ["."]


### PR DESCRIPTION
Adds a sample to demonstrate adding a Session Parameter based on values detected by an intent.

Changes scope of test fixtures from session to function.

Adds a new param "drop_none_params" to the detect_intent method on the Session runner.  When locally running a sample, this will make sure that the parameter state displayed is consistent with the state in the Dialogflow CX console (as any parameter set to none is removed from the session parameters, by convention)