### PR TITLE
fix: Change bucket name in Terraform scripts to use project ID

### DIFF
--- a/dialogflow-cx/terraform/main.tf
+++ b/dialogflow-cx/terraform/main.tf
@@ -54,7 +54,7 @@ data "archive_file" "source" {
 
 resource "google_storage_bucket_object" "archive" {
   name       = "index.zip"
-  bucket     = "ccai-samples-df-tf"
+  bucket     = "${var.project_id}-ccai-samples-df-tf"
   source     = data.archive_file.source.output_path
   depends_on = [data.archive_file.source]
 }

--- a/oidc/main.tf
+++ b/oidc/main.tf
@@ -53,7 +53,7 @@ resource "google_project_service" "service" {
 
 resource "google_storage_bucket" "bucket" {
   project                     = var.project_id
-  name                        = "ccai-samples-df-tf"
+  name                        = "${var.project_id}-ccai-samples-df-tf"
   location                    = "US"
   uniform_bucket_level_access = true
   force_destroy               = true


### PR DESCRIPTION
This avoids the case where the static bucket name is already taken and the Terraform plan or apply throws an error.